### PR TITLE
Support noble only

### DIFF
--- a/jammy/debian/changelog
+++ b/jammy/debian/changelog
@@ -1,6 +1,0 @@
-gz-transport15 (14.999.999-1~jammy) jammy; urgency=medium
-
-  * Stub to be removed after first entry
-
- -- Carlos Aguero <caguero@openrobotics.org>  Tue, 08 Oct 2024 21:00:24 +0200
-

--- a/jammy/debian/compat
+++ b/jammy/debian/compat
@@ -1,1 +1,0 @@
-../../ubuntu/debian/compat

--- a/jammy/debian/control
+++ b/jammy/debian/control
@@ -1,1 +1,0 @@
-../../ubuntu/debian/control

--- a/jammy/debian/copyright
+++ b/jammy/debian/copyright
@@ -1,1 +1,0 @@
-../../ubuntu/debian/debian_copyright_2022

--- a/jammy/debian/docs
+++ b/jammy/debian/docs
@@ -1,1 +1,0 @@
-../../ubuntu/debian/docs

--- a/jammy/debian/gz-transport15-cli.install
+++ b/jammy/debian/gz-transport15-cli.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/gz-transport-cli.install

--- a/jammy/debian/libgz-transport15-core-dev.install
+++ b/jammy/debian/libgz-transport15-core-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-transport-core-dev.install

--- a/jammy/debian/libgz-transport15-dev.install
+++ b/jammy/debian/libgz-transport15-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-transport-dev.install

--- a/jammy/debian/libgz-transport15-log-dev.install
+++ b/jammy/debian/libgz-transport15-log-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-transport-log-dev.install

--- a/jammy/debian/libgz-transport15-log.install
+++ b/jammy/debian/libgz-transport15-log.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-transport-log.install

--- a/jammy/debian/libgz-transport15-parameters-dev.install
+++ b/jammy/debian/libgz-transport15-parameters-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-transport-parameters-dev.install

--- a/jammy/debian/libgz-transport15-parameters.install
+++ b/jammy/debian/libgz-transport15-parameters.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-transport-parameters.install

--- a/jammy/debian/libgz-transport15.install
+++ b/jammy/debian/libgz-transport15.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-transport.install

--- a/jammy/debian/python3-gz-transport15.install
+++ b/jammy/debian/python3-gz-transport15.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/python3-gz-transport.install

--- a/jammy/debian/rules
+++ b/jammy/debian/rules
@@ -1,1 +1,0 @@
-../../ubuntu/debian/rules

--- a/jammy/debian/source
+++ b/jammy/debian/source
@@ -1,1 +1,0 @@
-../../ubuntu/debian/source

--- a/jammy/debian/tests
+++ b/jammy/debian/tests
@@ -1,1 +1,0 @@
-../../ubuntu/debian/tests

--- a/jammy/debian/watch
+++ b/jammy/debian/watch
@@ -1,1 +1,0 @@
-../../ubuntu/debian/watch


### PR DESCRIPTION
The next Gazebo distribution will support only noble and newer versions of Ubuntu. This PR adds noble and removes older distributions.