### PR TITLE
Remove version from package name

### DIFF
--- a/ubuntu/debian/libgz-transport-core-dev.install
+++ b/ubuntu/debian/libgz-transport-core-dev.install
@@ -2,7 +2,7 @@ usr/include/*/transport[0-9][0-9]/*/transport.hh
 usr/include/*/transport[0-9][0-9]/*/transport/*.h
 usr/include/*/transport[0-9][0-9]/*/transport/*.hh
 usr/include/*/transport[0-9][0-9]/*/transport/detail/*.hh
-usr/lib/*/lib*-transport[0-9][0-9].so
-usr/lib/*/pkgconfig/*-transport[0-9][0-9].pc
-usr/lib/*/cmake/*-transport[0-9][0-9]/*-transport*
-usr/share/gz/*-transport*/*-transport[0-9][0-9].tag.xml
+usr/lib/*/lib*-transport.so
+usr/lib/*/pkgconfig/*-transport.pc
+usr/lib/*/cmake/*-transport/*-transport*
+usr/share/gz/*-transport*/*-transport.tag.xml

--- a/ubuntu/debian/libgz-transport-dev.install
+++ b/ubuntu/debian/libgz-transport-dev.install
@@ -1,1 +1,1 @@
-usr/lib/*/cmake/*-transport[0-9][0-9]-all/*-transport[0-9][0-9]-all*
+usr/lib/*/cmake/*-transport-all/*-transport-all*

--- a/ubuntu/debian/libgz-transport-log-dev.install
+++ b/ubuntu/debian/libgz-transport-log-dev.install
@@ -1,6 +1,6 @@
 usr/include/*/transport*/*/transport/log.hh
 usr/include/*/transport*/*/transport/log/*
-usr/lib/*/cmake/*-transport[0-9][0-9]-log/*
-usr/lib/*/lib*-transport[0-9][0-9]-log.so
-usr/lib/*/pkgconfig/*-transport[0-9][0-9]-log.pc
-usr/share/gz/*-transport[0-9][0-9]/sql/*
+usr/lib/*/cmake/*-transport-log/*
+usr/lib/*/lib*-transport-log.so
+usr/lib/*/pkgconfig/*-transport-log.pc
+usr/share/gz/*-transport/sql/*

--- a/ubuntu/debian/libgz-transport-log.install
+++ b/ubuntu/debian/libgz-transport-log.install
@@ -1,3 +1,3 @@
-usr/lib/*/lib*-transport[0-9][0-9]-log.so.*
+usr/lib/*/lib*-transport-log.so.*
 usr/lib/ruby/*/cmdlog[0-9][0-9].rb
 usr/share/*/transportlog[0-9][0-9].yaml

--- a/ubuntu/debian/libgz-transport-parameters-dev.install
+++ b/ubuntu/debian/libgz-transport-parameters-dev.install
@@ -1,5 +1,5 @@
 usr/include/*/transport*/*/transport/parameters.hh
 usr/include/*/transport*/*/transport/parameters/*
-usr/lib/*/cmake/*-transport[0-9][0-9]-parameters/*
-usr/lib/*/lib*-transport[0-9][0-9]-parameters.so
-usr/lib/*/pkgconfig/*-transport[0-9][0-9]-parameters.pc
+usr/lib/*/cmake/*-transport-parameters/*
+usr/lib/*/lib*-transport-parameters.so
+usr/lib/*/pkgconfig/*-transport-parameters.pc

--- a/ubuntu/debian/libgz-transport-parameters.install
+++ b/ubuntu/debian/libgz-transport-parameters.install
@@ -1,3 +1,3 @@
-usr/lib/*/lib*-transport[0-9][0-9]-parameters.so.*
+usr/lib/*/lib*-transport-parameters.so.*
 usr/lib/ruby/*/cmdparam[0-9][0-9].rb
 usr/share/*/transportparam[0-9][0-9].yaml

--- a/ubuntu/debian/libgz-transport.install
+++ b/ubuntu/debian/libgz-transport.install
@@ -1,1 +1,1 @@
-usr/lib/*/lib*-transport[0-9][0-9].so.*
+usr/lib/*/lib*-transport.so.*

--- a/ubuntu/debian/tests/build
+++ b/ubuntu/debian/tests/build
@@ -20,7 +20,7 @@ int main()
 }
 EOF
 
-g++ -o gztest gztest.cc `pkg-config --cflags --libs gz-transport15`
+g++ -o gztest gztest.cc `pkg-config --cflags --libs gz-transport`
 echo "build: OK"
 [ -x gztest ]
 ./gztest
@@ -31,11 +31,11 @@ cmake_minimum_required(VERSION 3.5)
 
 project(gz_test VERSION 1.0.0)
 
-find_package(gz-transport15 15.0.0 REQUIRED)
+find_package(gz-transport 15.0.0 REQUIRED)
 add_executable(gztest gztest.cc)
 target_link_libraries(gztest
    PUBLIC
-      gz-transport15::gz-transport15)
+      gz-transport::gz-transport)
 EOF
 
 cmake .


### PR DESCRIPTION
Follow-up to https://github.com/gazebosim/gz-transport/pull/594.

* Removes version numbers from some installation paths
* Removes version numbers from cmake and pkg-config tests

## Failed build on main

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz-transport15-debbuilder&build=73)](https://build.osrfoundation.org/job/gz-transport15-debbuilder/73/) https://build.osrfoundation.org/job/gz-transport15-debbuilder/73/

## Fixed with this branch

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz-transport15-debbuilder&build=75)](https://build.osrfoundation.org/job/gz-transport15-debbuilder/75/) https://build.osrfoundation.org/job/gz-transport15-debbuilder/75/