### PR TITLE
rules: install Doxygen xml to unversioned folder

### DIFF
--- a/ubuntu/debian/rules
+++ b/ubuntu/debian/rules
@@ -28,6 +28,8 @@ override_dh_auto_build:
 	dh_auto_build
 
 override_dh_install:
+	install -d debian/tmp/usr/share/gz/gz-transport/
+	install ./obj-*/*.tag.xml debian/tmp/usr/share/gz/gz-transport/
 	dh_install --
 	# need to remove files present in components
 	$(RM) debian/libgz-transport*-core-dev/usr/include/gz/transport*/gz/transport/log.hh


### PR DESCRIPTION
Fixes error in https://github.com/gazebosim/gz-gui/pull/674

~~~
Error. The following warnings were found in gz-doxygen.warn.
  error: Tag file '/usr/share/gz/gz-transport/gz-transport.tag.xml' does not exist or is not a file. Skipping it...
~~~

Follow-up to https://github.com/gazebosim/gz-transport/pull/594.