### PR TITLE
Add explicit dependency on libzenohc

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -61,7 +61,7 @@ Package: libgz-transport15
 Architecture: any
 Section: libs
 Pre-Depends: ${misc:Pre-Depends}
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, libzenohc
 Recommends: gz-transport15-cli
 Multi-Arch: same
 Description: Gazebo Transport Library - Shared library


### PR DESCRIPTION
shlibdeps errors out with
```
dpkg-shlibdeps: warning: can't extract name and version from library name 'libzenohc.so'
```
so this adds an explicit dependency.