### PR TITLE
test: increase cmake version to 3.22.1

### DIFF
--- a/ubuntu/debian/tests/build
+++ b/ubuntu/debian/tests/build
@@ -27,7 +27,7 @@ echo "build: OK"
 echo "run: OK"
 
 cat <<EOF > CMakeLists.txt
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22.1)
 
 project(gz_test VERSION 1.0.0)
 


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1503, similar to https://github.com/gazebo-release/gz-rotary-cmake-release/pull/2.